### PR TITLE
Add a missing comma separator in install_requires

### DIFF
--- a/cai/datasets.py
+++ b/cai/datasets.py
@@ -1040,7 +1040,8 @@ def load_images_from_folders(seed=None, root_dir=None, lab=False,
         n.lower().endswith(".jpg") or
         n.lower().endswith(".jpeg") or
         n.lower().endswith(".tif") or
-        n.lower().endswith(".tiff")
+        n.lower().endswith(".tiff") or
+        n.lower().endswith(".bmp")
         ]
       random.shuffle(paths)
       cat_total = len(paths)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(name='cai',
                         'pandas>=0.22.0',
                         'scikit-image>=0.15.0',
                         'opencv-python>=4.1.2.30', 
-                        'scikit-learn>=0.21.0'
+                        'scikit-learn>=0.21.0',
                         'numpy'],
       classifiers=[
           'Intended Audience :: Developers',


### PR DESCRIPTION
Currently there is no comma between 'scikit-learn>=0.21.0' and numpy, which results in a big error when those respective pip-packages are not yet installed. This pull request should fix this error.