### PR TITLE
change lr to learning_rate

### DIFF
--- a/cai/datasets.py
+++ b/cai/datasets.py
@@ -836,7 +836,7 @@ def train_model_on_dataset(model, dataset,  base_model_name, plrscheduler,  batc
     batches_per_validation = np.floor(x_test.shape[0]/batch_size)    
     model_name = base_model_name+'.h5'
     csv_name = base_model_name+'.csv'
-    opt = keras.optimizers.SGD(lr=0.1, momentum=momentum, nesterov=nesterov)
+    opt = keras.optimizers.SGD(learning_rate=0.1, momentum=momentum, nesterov=nesterov)
 
     model.compile(
         loss='categorical_crossentropy',

--- a/cai/inception_v3.py
+++ b/cai/inception_v3.py
@@ -833,7 +833,7 @@ def compiled_two_path_inception_v3(
     predictions = keras.layers.Activation('softmax',name='prediction')(x)
     model = Model(inputs=base_model.input, outputs=predictions)
     if optimizer is None:
-        opt = keras.optimizers.SGD(lr=0.01, momentum=0.9, nesterov=True)
+        opt = keras.optimizers.SGD(learning_rate=0.01, momentum=0.9, nesterov=True)
     else:
         opt = optimizer
     model.compile(


### PR DESCRIPTION
Hi,,
In recent Tensorflow versions, `learning_rate` is used instead of `lr`. Despite `lr`, there is a warning. This PR will fix it.

`WARNING:absl:`lr` is deprecated in Keras optimizer, please use `learning_rate` or use the legacy optimizer, e.g.,tf.keras.optimizers.legacy.SGD.
`

Thanks